### PR TITLE
fix(CMakeLists): add options to select backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(lvgl)
+project(lvgl LANGUAGES C)
 
 set(CMAKE_C_STANDARD 99)#C99 # lvgl officially support C99 and above
 set(CMAKE_CXX_STANDARD 17)#C17
@@ -7,18 +7,41 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
 
-add_subdirectory(lvgl)
+add_subdirectory(lvgl EXCLUDE_FROM_ALL)
 target_include_directories(lvgl PUBLIC ${PROJECT_SOURCE_DIR})
 
 add_executable(main main.c mouse_cursor_icon.c)
 
-include(${CMAKE_CURRENT_LIST_DIR}/lvgl/tests/FindLibDRM.cmake)
-include_directories(${Libdrm_INCLUDE_DIRS})
+option(USE_FBDEV "Use the framebuffer backend" ON)
+option(USE_DRM "Use the DRM backend" OFF)
+option(USE_SDL2 "Use the SDL2 backend" OFF)
+option(USE_THOR "Link with the ThorVG vector grapics library" OFF)
 
-find_package(SDL2)
-find_package(SDL2_image)
-include_directories(${SDL2_INCLUDE_DIRS} ${SDL2_IMAGE_INCLUDE_DIRS})
+if(USE_FBDEV)
+   add_compile_definitions(LV_USE_LINUX_FBDEV=1)
+elseif(USE_DRM)
+   add_compile_definitions(LV_USE_LINUX_DRM=1)
+   include(${CMAKE_CURRENT_LIST_DIR}/lvgl/tests/FindLibDRM.cmake)
+   include_directories(${Libdrm_INCLUDE_DIRS})
+   target_link_libraries(main ${Libdrm_LIBRARIES})
+elseif(USE_SDL2)
+   add_compile_definitions(LV_USE_SDL=1)
+   find_package(SDL2)
+   find_package(SDL2_image)
+   include_directories(${SDL2_INCLUDE_DIRS} ${SDL2_IMAGE_INCLUDE_DIRS})
+   target_link_libraries(main ${SDL2_LIBRARIES} ${SDL2_IMAGE_LIBRARIES})
+endif()
 
-target_link_libraries(main lvgl lvgl::examples lvgl::demos lvgl::thorvg ${SDL2_LIBRARIES} ${SDL2_IMAGE_LIBRARIES} ${Libdrm_LIBRARIES} m pthread)
+if(USE_THOR)
+   enable_language(CXX)
+   target_link_libraries(main lvgl::thorvg)
+   add_compile_definitions(LV_USE_THORVG_INTERNAL=1)
+else()
+   add_compile_definitions(LV_USE_THORVG_INTERNAL=0)
+endif()
+
+target_link_libraries(main lvgl lvgl::examples lvgl::demos m pthread)
 add_custom_target (run COMMAND ${EXECUTABLE_OUTPUT_PATH}/main DEPENDS main)
 
+set_target_properties(main PROPERTIES OUTPUT_NAME lv_port_linux)
+install(TARGETS main DESTINATION local/bin)

--- a/lv_conf.h
+++ b/lv_conf.h
@@ -693,7 +693,9 @@
 #define LV_USE_VECTOR_GRAPHIC  1
 
 /* Enable ThorVG (vector graphics library) from the src/libs folder */
-#define LV_USE_THORVG_INTERNAL 1
+#ifndef LV_USE_THORVG_INTERNAL
+#define LV_USE_THORVG_INTERNAL 0
+#endif // LV_USE_THORVG_INTERNAL
 
 /* Enable ThorVG by assuming that its installed and linked to the project */
 #define LV_USE_THORVG_EXTERNAL 0
@@ -850,7 +852,9 @@
 #endif
 
 /*Driver for /dev/fb*/
+#ifndef LV_USE_LINUX_FBDEV
 #define LV_USE_LINUX_FBDEV      1
+#endif // LV_USE_LINUX_FBDEV
 #if LV_USE_LINUX_FBDEV
     #define LV_LINUX_FBDEV_BSD           0
     #define LV_LINUX_FBDEV_RENDER_MODE   LV_DISPLAY_RENDER_MODE_DIRECT


### PR DESCRIPTION
Add options `USE_FBDEV`, `USE_DRM`, `USE_SDL2` to CMakeLists.txt to select the backend. Also change `lv_conf.h` to make fbdev the optional default.

Add option `USE_THOR` to CMakeLists.txt so as to make using thorvg optional.  This way C++ is not required for building. Also change `lv_conf.h` to make building the internal ThorVG optional.

Mark lvgl as `EXCLUDE_FROM_ALL` in CMakeLists.txt so it does not get installed on the target when `lv_port_linux` is installed.

These changes are useful to enable including this package in buildroot (see issue #17).