### PR TITLE
fix(timer) delay execution only until the next timer fires up

### DIFF
--- a/main.c
+++ b/main.c
@@ -52,7 +52,8 @@ int main(void)
 
     /*Handle LVGL tasks*/
     while(1) {
-        usleep(lv_timer_handler() * 1000);
+        uint32_t idle_time = lv_timer_handler(); /*Returns the time to the next timer execution*/
+        usleep(idle_time * 1000);
     }
 
     return 0;

--- a/main.c
+++ b/main.c
@@ -52,8 +52,7 @@ int main(void)
 
     /*Handle LVGL tasks*/
     while(1) {
-        lv_timer_handler();
-        usleep(5000);
+        usleep(lv_timer_handler() * 1000);
     }
 
     return 0;


### PR DESCRIPTION
lv_timer_handle returns the time in ms until the next timer will fire. We need to delay only that much time for optimal execution.