### PR TITLE
build: find wl protocols using sysroot and generate them inside build folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,10 +75,14 @@ if (LV_USE_WAYLAND)
     pkg_check_modules(WAYLAND_PROTOCOLS REQUIRED wayland-protocols>=1.25)
     pkg_get_variable(WAYLAND_PROTOCOLS_BASE wayland-protocols pkgdatadir)
 
-    execute_process(COMMAND "scripts/gen_wl_protocols.sh" OUTPUT_VARIABLE WAYLAND_PROTOCOLS_SRC)
+    execute_process(WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+                    COMMAND "scripts/gen_wl_protocols.sh" "${CMAKE_CURRENT_BINARY_DIR}/protocols"
+                    OUTPUT_VARIABLE WAYLAND_PROTOCOLS_SRC
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    string(REPLACE "\n" ";" WAYLAND_PROTOCOLS_SRC "${WAYLAND_PROTOCOLS_SRC}")
 
-    list(APPEND PKG_CONFIG_INC "${PROJECT_SOURCE_DIR}/wl_protocols")
-    list(APPEND LV_LINUX_BACKEND_SRC src/lib/display_backends/wayland.c wl_protocols/wayland_xdg_shell.c)
+    list(APPEND PKG_CONFIG_INC "${CMAKE_CURRENT_BINARY_DIR}/protocols")
+    list(APPEND LV_LINUX_BACKEND_SRC src/lib/display_backends/wayland.c "${WAYLAND_PROTOCOLS_SRC}")
 
 endif()
 

--- a/scripts/gen_wl_protocols.sh
+++ b/scripts/gen_wl_protocols.sh
@@ -1,16 +1,21 @@
 #!/bin/sh
 # Generate wayland xdg shell protocol
 
-if ! test -d /usr/share/wayland-protocols
+OUTPUT_DIR="$1"
+PROTOCOL_ROOT="${SYSROOT:-}/usr/share/wayland-protocols"
+
+if ! test -d $PROTOCOL_ROOT
 then
+	echo "Error: Wayland protocols not found at $PROTOCOL_ROOT" >&2
+	echo "For cross-compilation, set SYSROOT environment variable" >&2
 	exit 1
 fi
 
-if ! test -d wl_protocols
+if ! test -d $OUTPUT_DIR
 then
-	mkdir wl_protocols
-	wayland-scanner client-header "/usr/share/wayland-protocols/stable/xdg-shell/xdg-shell.xml" "wl_protocols/wayland_xdg_shell.h"
-	wayland-scanner private-code "/usr/share/wayland-protocols/stable/xdg-shell/xdg-shell.xml" "wl_protocols/wayland_xdg_shell.c"
+	mkdir $OUTPUT_DIR
+	wayland-scanner client-header "$PROTOCOL_ROOT/stable/xdg-shell/xdg-shell.xml" "$OUTPUT_DIR/wayland_xdg_shell.h"
+	wayland-scanner private-code  "$PROTOCOL_ROOT/stable/xdg-shell/xdg-shell.xml" "$OUTPUT_DIR/wayland_xdg_shell.c"
 fi
 
-printf "wl_protocols/wayland_xdg_shell.c"
+echo "$OUTPUT_DIR/wayland_xdg_shell.c"


### PR DESCRIPTION
Simple enhancements to the `wl_protocols` generation script:

- Allow defining the output folder and replace the previously used `wl_protocols` folder to the build folder in `cmake`
  - I wasn't liking having to manually remove two folders to do a clean build
- Allow easy addition of new protocols as I have a feeling we will needed this in not so distant future
  - To support new we simply need to `echo` the generated private-code and it will be collected by cmake
- Prefix the protocols folder with `$SYSROOT` to support cross-compilation by finding protocols in the target system's sysroot rather than the host system

cc @etag4048 @anaGrad 