### PR TITLE
ci: replace ubuntu 20.04 with ubuntu 24.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,8 @@ jobs:
         os:
           - { image: "debian:bullseye", dockerfile: "Dockerfile_DEBIAN" }
           - { image: "debian:bookworm", dockerfile: "Dockerfile_DEBIAN" }
-          - { image: "ubuntu:20.04", dockerfile: "Dockerfile_DEBIAN" }
           - { image: "ubuntu:22.04", dockerfile: "Dockerfile_DEBIAN" }
+          - { image: "ubuntu:24.04", dockerfile: "Dockerfile_DEBIAN" }
       fail-fast: false
 
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Ubuntu 20.04 EOL is in 2 days and is now causing problems while fetching packages. Also Ubuntu 24.04 is missing from the CI

This PR replaces one with the other 