### PR TITLE
fix: order of width,height parameter in X11 backend

### DIFF
--- a/src/lib/display_backends/x11.c
+++ b/src/lib/display_backends/x11.c
@@ -93,7 +93,7 @@ static lv_display_t *init_x11(void)
     LV_IMG_DECLARE(mouse_cursor_icon);
 
     disp = lv_x11_window_create("LVGL simulator",
-            settings.window_height, settings.window_width);
+           settings.window_width , settings.window_height);
 
     disp = lv_display_get_default();
 


### PR DESCRIPTION
While using X11 simulation I noticed that width and height were not correct, and I found they are switched, fixing this line will make the window size correct