### PR TITLE
arch: update manifest to use new lv_conf.defaults

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -40,9 +40,9 @@
             ],
             "actions": [
                 {
-                    "toReplace": "#define LV_COLOR_DEPTH \\d+",
-                    "newContent": "#define LV_COLOR_DEPTH {value}",
-                    "filePath": "lv_conf.h"
+                    "toReplace": "LV_COLOR_DEPTH \\d+",
+                    "newContent": "LV_COLOR_DEPTH {value}",
+                    "filePath": "lv_conf.defaults"
                 }
             ]
         },
@@ -62,9 +62,9 @@
             ],
             "actions": [
                 {
-                    "toReplace": "#define LV_USE_PERF_MONITOR .*",
-                    "newContent": "#define LV_USE_PERF_MONITOR {value}",
-                    "filePath": "lv_conf.h"
+                    "toReplace": "LV_USE_PERF_MONITOR .*",
+                    "newContent": "LV_USE_PERF_MONITOR {value}",
+                    "filePath": "lv_conf.defaults"
                 }
             ]
         },
@@ -85,25 +85,35 @@
                     "name": "SDL",
                     "value": "2"
                 }
+                {
+                    "name": "Wayland",
+                    "value": "3"
+                }
             ],
             "actions": [
                 {
                     "ifValue": "0",
-                    "toReplace": "#define LV_USE_LINUX_FBDEV +\\d+",
-                    "newContent": "#define LV_USE_LINUX_FBDEV 1",
-                    "filePath": "lv_conf.h"
+                    "toReplace": "LV_USE_LINUX_FBDEV +\\d+",
+                    "newContent": "LV_USE_LINUX_FBDEV 1",
+                    "filePath": "lv_conf.defaults"
                 },
                 {
                     "ifValue": "1",
-                    "toReplace": "#define LV_USE_LINUX_DRM +\\d+",
-                    "newContent": "#define LV_USE_LINUX_DRM 1",
-                    "filePath": "lv_conf.h"
+                    "toReplace": "LV_USE_LINUX_DRM +\\d+",
+                    "newContent": "LV_USE_LINUX_DRM 1",
+                    "filePath": "lv_conf.defaults"
                 },
                 {
                     "ifValue": "2",
-                    "toReplace": "#define LV_USE_SDL +\\d+",
-                    "newContent": "#define LV_USE_SDL 1",
-                    "filePath": "lv_conf.h"
+                    "toReplace": "LV_USE_SDL +\\d+",
+                    "newContent": "LV_USE_SDL 1",
+                    "filePath": "lv_conf.defaults"
+                }
+                {
+                    "ifValue": "3",
+                    "toReplace": "LV_USE_WAYLAND +\\d+",
+                    "newContent": "LV_USE_WAYLAND 1",
+                    "filePath": "lv_conf.defaults"
                 }
             ]
         }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch manifest to edit LVGL settings in lv_conf.defaults instead of lv_conf.h, and add a Wayland backend option.

- **Refactors**
  - Point config actions to lv_conf.defaults for LV_COLOR_DEPTH, LV_USE_PERF_MONITOR, and backend flags.
  - Update match patterns to align with defaults format (drop "#define" prefix).

- **New Features**
  - Add "Wayland" option (value 3) with LV_USE_WAYLAND 1 when selected.

<sup>Written for commit cf3250e5862d5884478c8987d955c7afa6be9e82. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

