### PR TITLE
arch: add another missing comma to manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -84,7 +84,7 @@
                 {
                     "name": "SDL",
                     "value": "2"
-                }
+                },
                 {
                     "name": "Wayland",
                     "value": "3"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix invalid JSON in manifest.json by adding the missing comma after the SDL entry. Restores valid syntax so the manifest parses correctly during builds and runtime.

<sup>Written for commit f13c6080852cf49d4914dc4d1773ee27e0cf748c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

