### PR TITLE
The `CONFIG` variable should be a string, not a bool.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wpedantic")
 
-option(CONFIG "Config to use leave empty for `lv_conf.defaults`" "default")
+set(CONFIG "default" CACHE STRING "Config to use leave empty for `lv_conf.defaults`")
 
 set(LV_CONF_DEFAULTS_PATH "${CMAKE_SOURCE_DIR}/lv_conf.defaults")
 set(LV_CONF_DEFAULTS_OLD_PATH "${CMAKE_SOURCE_DIR}/lv_conf.defaults.old")


### PR DESCRIPTION
The CMake `option` function is a short-hand for creating a boolean cache variable, but since we want to set a string value that does _not_ work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Convert CONFIG to a cached STRING in CMake instead of a boolean option, so it accepts string values for config selection and avoids incorrect boolean behavior.

<sup>Written for commit a520286858ab2b9b07cdba14169114e7d2b6138e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

