### PR TITLE
Fix typos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
         

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Check the documentation of the drivers for more details
 
 ## Permissions
 
-By default, unpriviledged users don't have access to the framebuffer device `/dev/fb0`. In such cases, you can either run the application
+By default, unprivileged users don't have access to the framebuffer device `/dev/fb0`. In such cases, you can either run the application
 with `sudo` privileges or you can grant access to the `video` group.
 
 ```bash

--- a/src/lib/backends.h
+++ b/src/lib/backends.h
@@ -1,7 +1,7 @@
 /**
  * @file backends.h
  *
- * Interface for abstration layer of a device backend
+ * Interface for abstraction layer of a device backend
  *
  * Copyright (c) 2025 EDGEMTech Ltd.
  *

--- a/src/lib/display_backends/wayland.c
+++ b/src/lib/display_backends/wayland.c
@@ -5,7 +5,7 @@
  *
  * Based on the original file from the repository
  *
- * - Move to a seperate file
+ * - Move to a separate file
  *   2025 EDGEMTech Ltd.
  *
  * Author: EDGEMTech Ltd, Erik Tagirov (erik.tagirov@edgemtech.ch)
@@ -116,7 +116,7 @@ static lv_display_t *init_wayland(void)
 /**
  * The run loop of the DRM driver
  *
- * @note Currently, the wayland driver calls lv_timer_handler internaly
+ * @note Currently, the wayland driver calls lv_timer_handler internally
  * The wayland driver needs to be re-written to match the other backends
  */
 static void run_loop_wayland(void)

--- a/src/lib/driver_backends.h
+++ b/src/lib/driver_backends.h
@@ -1,8 +1,8 @@
 /**
  * @file driver_backends.h
  *
- * provides an abstration to support multiple graphical
- * driver backends at the same time whitout recompiling everything
+ * provides an abstraction to support multiple graphical
+ * driver backends at the same time without recompiling everything
  * each time
  *
  * E.g: this means LVGL can be compiled with both SDL or X11

--- a/src/lib/indev_backends/evdev.c
+++ b/src/lib/indev_backends/evdev.c
@@ -146,7 +146,7 @@ static void set_mouse_cursor_icon(lv_indev_t *indev, lv_display_t *display)
  * Use 'evtest' to find the correct input device. /dev/input/by-id/ is recommended if possible
  * Use /dev/input/by-id/my-mouse-or-touchscreen or /dev/input/eventX
  *
- * If LV_LINUX_EVDEV_POINTER_DEVICE is not set, automatic evdev disovery will start
+ * If LV_LINUX_EVDEV_POINTER_DEVICE is not set, automatic evdev discovery will start
  *
  * @param display the LVGL display
  *

--- a/src/main.c
+++ b/src/main.c
@@ -67,7 +67,7 @@ static void print_usage(void)
 
 /**
  * @brief Configure simulator
- * @description process arguments recieved by the program to select
+ * @description process arguments received by the program to select
  * appropriate options
  * @param argc the count of arguments in argv
  * @param argv The arguments


### PR DESCRIPTION
This PR fixes a few typos I spotted in the project.
It also bumps `actions/checkout` in `build.yml` to latest released version `v6`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed spelling typos across README and source comments to improve clarity. Updated the build workflow to use actions/checkout v6.

<sup>Written for commit e7ddbe04e99d822c1799d6205e4a34c12937c23c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

