### PR TITLE
docs(readme): fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ eg: `-DCONFIG=wayland` will use `configs/wayland.defaults`.
 ## Install dependencies
 
 Install the required dependencies for the selected drivers by checking 
-the documentation for each driver [here](https://docs.lvgl.io/master/details/integration/embedded_linux/drivers/index.html)
+the documentation for each driver [here](https://docs.lvgl.io/master/integration/embedded_linux/drivers/)
 
 You can also check the [Dockerfiles](docker/) to get the names
 of the packages for various distributions


### PR DESCRIPTION
This PR fixes a broken link I spotted in `README.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the broken link in README to the LVGL embedded Linux driver documentation, pointing to the correct page. This ensures users can access dependency instructions for selected drivers.

<sup>Written for commit 81389123b3cae4e97f563e281a5bba51ce6a9d9b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

